### PR TITLE
Creates open graph images for blog posts programmatically

### DIFF
--- a/src/app/[slug]/og.png/route.tsx
+++ b/src/app/[slug]/og.png/route.tsx
@@ -4,21 +4,23 @@ import fs from "fs/promises"
 import { format } from "date-fns"
 import { ImageResponse } from "next/og"
 
-import { getStory } from "@/lib/get-stories"
+import { getSlugs, getStory } from "@/lib/get-stories"
 
-export const size = {
+const size = {
   width: 1200,
   height: 630,
 }
-export const contentType = "image/png"
 
-export default async function BlogPreviewImage({
-  params,
-}: {
-  params: { slug: string }
-}) {
+export async function generateStaticParams() {
+  return await getSlugs()
+}
+
+export async function GET(
+  _: Request,
+  { params }: { params: { slug: string } }
+) {
   const story = await getStory(params.slug)
-  const url = new URL(`../../../public${story.data.image}`, import.meta.url)
+  const url = new URL(`../../../../public${story.data.image}`, import.meta.url)
   const imgData = await fs.readFile(url.pathname)
 
   const [interRegular, interBold, interLight] = await Promise.all([

--- a/src/app/[slug]/og.png/route.tsx
+++ b/src/app/[slug]/og.png/route.tsx
@@ -73,9 +73,10 @@ export async function GET(
           </div>
           <div
             style={{
-              fontSize: 70,
+              fontSize: 52,
               fontWeight: 300,
-              paddingRight: 20,
+              paddingTop: 8,
+              paddingRight: 60,
             }}
           >
             {story.data.description}
@@ -84,8 +85,8 @@ export async function GET(
             style={{
               display: "flex",
               flexDirection: "row",
-              paddingTop: 14,
-              fontSize: 46,
+              paddingTop: 18,
+              fontSize: 38,
               fontWeight: 300,
             }}
           >

--- a/src/app/[slug]/opengraph-image.tsx
+++ b/src/app/[slug]/opengraph-image.tsx
@@ -1,0 +1,139 @@
+/* eslint-disable @next/next/no-img-element */
+import fs from "fs/promises"
+
+import { format } from "date-fns"
+import { ImageResponse } from "next/og"
+
+import { getStory } from "@/lib/get-stories"
+
+export const size = {
+  width: 1200,
+  height: 630,
+}
+export const contentType = "image/png"
+
+export default async function BlogPreviewImage({
+  params,
+}: {
+  params: { slug: string }
+}) {
+  const story = await getStory(params.slug)
+  const url = new URL(`../../../public${story.data.image}`, import.meta.url)
+  const imgData = await fs.readFile(url.pathname)
+
+  const [interRegular, interBold, interLight] = await Promise.all([
+    fetchFont(`https://fonts.googleapis.com/css2?family=Inter:opsz@14..32`),
+    fetchFont(
+      `https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,700`
+    ),
+    fetchFont(
+      `https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,300`
+    ),
+  ])
+
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          fontFamily: "Inter",
+          textShadow: "0 0 8px rgba(0, 0, 0, 0.5)",
+          color: "white",
+        }}
+      >
+        <img
+          src={imgData.buffer as any}
+          alt=""
+          tw="absolute top-0 left-0 right-0 bottom-0"
+          style={{
+            filter: "blur(4px)",
+            objectFit: "cover",
+          }}
+        />
+        <div tw="absolute top-0 left-0 right-0 bottom-0 bg-black opacity-30" />
+        <div
+          tw="p-14"
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            justifyContent: "center",
+          }}
+        >
+          <div
+            style={{
+              fontSize: 104,
+              fontWeight: "bold",
+            }}
+          >
+            {story.data.title}
+          </div>
+          <div
+            style={{
+              fontSize: 70,
+              fontWeight: 300,
+              paddingRight: 20,
+            }}
+          >
+            {story.data.description}
+          </div>
+          <div
+            style={{
+              display: "flex",
+              flexDirection: "row",
+              paddingTop: 14,
+              fontSize: 46,
+              fontWeight: 300,
+            }}
+          >
+            {format(story.data.publication, "LLLL do, yyyy")} •{" "}
+            {story.readLength} min read
+          </div>
+        </div>
+      </div>
+    ),
+    {
+      // For convenience, we can re-use the exported opengraph-image
+      // size config to also set the ImageResponse's width and height.
+      ...size,
+      fonts: [
+        {
+          name: "Inter",
+          data: interLight,
+          style: "normal",
+          weight: 300,
+        },
+        {
+          name: "Inter",
+          data: interRegular,
+          style: "normal",
+          weight: 400,
+        },
+        {
+          name: "Inter",
+          data: interBold,
+          style: "normal",
+          weight: 700,
+        },
+      ],
+    }
+  )
+}
+
+/**
+ * Referenced https://github.com/vercel/satori/blob/618d565edb83270d9b829edc430788032e6f2bc6/playground/pages/api/font.ts#L86-L111
+ */
+async function fetchFont(gfontsUrl: string): Promise<ArrayBuffer> {
+  const css = await fetch(gfontsUrl, {
+    headers: {
+      // Make sure it returns TTF.
+      "User-Agent":
+        "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_8; de-at) AppleWebKit/533.21.1 (KHTML, like Gecko) Version/5.0.5 Safari/533.21.1",
+    },
+  }).then((res) => res.text())
+
+  const resource = css.match(/src: url\((.+)\) format\('(opentype|truetype)'\)/)
+  if (!resource) throw new Error("missing font resource")
+  return await fetch(resource[1]).then((res) => res.arrayBuffer())
+}

--- a/src/app/[slug]/page.tsx
+++ b/src/app/[slug]/page.tsx
@@ -35,6 +35,9 @@ export async function generateMetadata({ params }: PageProps) {
     return {
       title: data.title,
       description: data.description,
+      openGraph: {
+        images: `/${params.slug}/og.png`,
+      },
     }
   } catch (error) {
     console.error(error)


### PR DESCRIPTION
Wrote a blog post for the first time in a while, decided I wanted it to have an image, too!

The most confusing parts were:

- Loading a local image. Most of the examples show using`fetch` with the edge runtime. But I'm reading from the filesystem to get the story data so I can't use the edge runtime. Realized I needed to use fs to read the image data, too.
- Fonts. They reference using Google Fonts and show it in the playground, but it's not actually built into this by default at all. There's this closed issue https://github.com/vercel/satori/issues/337 of someone asking, and a response with a link to the docs that tout "Ability to download the subset characters of the font from Google Fonts" as a feature. But that's the _playground website feature_, not Next.js. Dug into the playground's source code to figure out how to do that. Discovered that you have to load each weight as a separate configuration, which is unfortunately inefficient.