### PR TITLE
Makes pump cycle duration configurable

### DIFF
--- a/src/app/(sketches)/ecosystem/ecosystem-models.ts
+++ b/src/app/(sketches)/ecosystem/ecosystem-models.ts
@@ -242,9 +242,11 @@ export type PumpSetting = {
   }
 }
 
+export const PUMP_MAX_CYCLE = 255
+
 export const PumpSchedule = z.object({
-  onPeriod: z.number().int().gte(0).lte(255),
-  offPeriod: z.number().int().gte(0).lte(255),
+  onPeriod: z.number().int().gte(0).lte(PUMP_MAX_CYCLE),
+  offPeriod: z.number().int().gte(0).lte(PUMP_MAX_CYCLE),
 })
 
 export type PumpSchedule = z.infer<typeof PumpSchedule>

--- a/src/app/(sketches)/ecosystem/pump/page.tsx
+++ b/src/app/(sketches)/ecosystem/pump/page.tsx
@@ -12,6 +12,7 @@ import {
   setPumpSchedule,
 } from "../ecosystem-methods"
 import {
+  PUMP_MAX_CYCLE,
   PumpInterruption,
   PumpMode,
   PumpSchedule,
@@ -116,6 +117,7 @@ export default async function PumpPage() {
           setting={setting}
           setPumpSchedule={handleSetSchedule}
           authenticated={authenticated}
+          maxCycle={PUMP_MAX_CYCLE}
         />
       </ErrorBoundary>
     </div>


### PR DESCRIPTION
Wanted to have the pump switch between on and off more often than once per hour. Just meant not hardcoding the cycle length to 60 and adding UI to change it; here's what it looks like now:

<img width="333" alt="Screenshot 2024-11-25 at 9 43 16 PM" src="https://github.com/user-attachments/assets/f4be0771-108f-4d90-8758-4f5c9f37ca0d">
